### PR TITLE
Fix require path of thrift module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,10 @@ node_js:
   - 0.8
   - 0.6
 
+before_install:
+- '[ "${TRAVIS_NODE_VERSION}" != "0.8" ] || npm install -g npm@1.4.28'
+- '[ "${TRAVIS_NODE_VERSION}" != "0.6" ] || npm install -g npm@1.3.26'
+- '[ "${TRAVIS_NODE_VERSION}" != "0.1*" ] || npm install -g npm@latest'
+
 before_script: npm run-script lint
 script: npm test

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -210,8 +210,8 @@
   if (typeof module !== 'undefined' && module.exports) {
     thrift = require('thrift');
     zipkinCore_types = require('./_thrift/zipkinCore/zipkinCore_types');
-    ttransport = require('../node_modules/thrift/lib/thrift/transport');
-    tprotocol = require('../node_modules/thrift/lib/thrift/protocol');
+    ttransport = require('thrift/lib/thrift/transport');
+    tprotocol = require('thrift/lib/thrift/protocol');
     module.exports = {
       _hexStringify: hexStringify,
       formatForRestkin: formatForRestkin,


### PR DESCRIPTION
If a parent module of node-tryfer also depends on the same version of thrift, the thrift module won't get installed in the node-tryfer/node_modules directory but in the node_modules directory of the parent.

This causes the relative require path to fail in lines 213 and 214 of formatters.js

```javascript
require('../node_modules/thrift/lib/thrift/transport');
```

See https://docs.npmjs.com/files/folders#cycles-conflicts-and-folder-parsimony for a clarification of how npm handles installing packages in sub modules if a parent module already depends on the same version.

Using the conventional path to require from the node_modules directory fixes the issue.

```javascript
require('thrift/lib/thrift/transport');
```
https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders